### PR TITLE
Keep title visible while being eddited

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -355,6 +355,7 @@ body .workspace-split.mod-vertical.mod-root .workspace-tab-header-container:hove
 body .sidebar-toggle-button:is(.mod-left, .mod-right):hover:hover,
 body .titlebar:hover:hover,
 body .workspace-split.mod-vertical.mod-root .view-header:hover,
+body.toggle-note-header .workspace-split.mod-vertical.mod-root .view-header:focus-within,
 body.is-grabbing.is-grabbing .app-container:not(.no-transition) .workspace-split .workspace-tabs .workspace-tab-header-container .workspace-tab-header-container-inner,
 body.is-grabbing.is-grabbing.is-grabbing.is-grabbing.is-grabbing .app-container:not(.no-transition) .workspace-split .workspace-tabs .workspace-tab-header-container{
 	opacity:1;


### PR DESCRIPTION
Hey, I've found that while editing a note file name, the note header will be hidden if the mouse isn't hovering on it. I've added a selector where it makes the elements visible so the header will be visible while we change the file name.

Thank you for this awesome theme!